### PR TITLE
Fix bug for post.categories and category.posts to use the configured wp_prefix and also enable category.posts to handle post_type and order

### DIFF
--- a/src/modules/Post/connectors/getPostTerms.js
+++ b/src/modules/Post/connectors/getPostTerms.js
@@ -1,4 +1,6 @@
-export default function (Terms, TermRelationships) {
+export default function (Terms, TermRelationships, settings) {
+  const {wp_prefix} = settings.privateSettings
+
   return function(postId) {
     return TermRelationships.findAll({
       where: {
@@ -9,7 +11,7 @@ export default function (Terms, TermRelationships) {
       }]
     }).then(relationships => {
       return relationships.map(r => {
-        return r.dataValues.wp_term
+        return r.dataValues[`${wp_prefix}term`]
       })
     })
   }

--- a/src/modules/Post/connectors/getTermPosts.js
+++ b/src/modules/Post/connectors/getTermPosts.js
@@ -1,6 +1,8 @@
 import {map} from 'lodash'
 
-export default function (TermRelationships, Post){
+export default function (TermRelationships, Post, settings){
+  const {wp_prefix} = settings.privateSettings
+
   return function(termId, { limit = 10, skip = 0 }) {
     return TermRelationships.findAll({
       attributes: [],
@@ -16,7 +18,7 @@ export default function (TermRelationships, Post){
       limit: limit,
       offset: skip
     }).then(posts => {
-      const p = map(posts, post => post.wp_post)
+      const p = map(posts, post => post[`${wp_prefix}post`])
       return p
     })
   }

--- a/src/modules/Post/connectors/getTermPosts.js
+++ b/src/modules/Post/connectors/getTermPosts.js
@@ -3,18 +3,21 @@ import {map} from 'lodash'
 export default function (TermRelationships, Post, settings){
   const {wp_prefix} = settings.privateSettings
 
-  return function(termId, { limit = 10, skip = 0 }) {
+  return function(termId, { post_type, order, limit = 10, skip = 0 }) {
+    const orderBy = order ? [Post, order.orderBy, order.direction] : [Post, 'post_date', 'DESC']
     return TermRelationships.findAll({
       attributes: [],
       include: [{
         model: Post,
         where: {
+          post_type: post_type,
           post_status: 'publish'
         }
       }],
       where: {
         term_taxonomy_id: termId
       },
+      order: [orderBy],
       limit: limit,
       offset: skip
     }).then(posts => {

--- a/src/modules/Post/connectors/index.js
+++ b/src/modules/Post/connectors/index.js
@@ -4,11 +4,11 @@ import getPostTerms from './getPostTerms'
 import getTermPosts from './getTermPosts'
 import getPostLayout from './getPostLayout'
 
-export default function ({Post, Postmeta, Terms, TermRelationships}) {
+export default function ({Post, Postmeta, Terms, TermRelationships}, settings) {
   return {
     getPost: getPost(Post),
     getPosts: getPosts(Post),
-    getPostTerms: getPostTerms(Terms, TermRelationships),
+    getPostTerms: getPostTerms(Terms, TermRelationships, settings),
     getTermPosts: getTermPosts(TermRelationships, Post),
     getPostLayout: getPostLayout(Postmeta),
   }

--- a/src/modules/Post/connectors/index.js
+++ b/src/modules/Post/connectors/index.js
@@ -9,7 +9,7 @@ export default function ({Post, Postmeta, Terms, TermRelationships}, settings) {
     getPost: getPost(Post),
     getPosts: getPosts(Post),
     getPostTerms: getPostTerms(Terms, TermRelationships, settings),
-    getTermPosts: getTermPosts(TermRelationships, Post),
+    getTermPosts: getTermPosts(TermRelationships, Post, settings),
     getPostLayout: getPostLayout(Postmeta),
   }
 }

--- a/src/schema/category.js
+++ b/src/schema/category.js
@@ -5,7 +5,7 @@ const Category = `
     term_id: Int!
     name: String
     slug: String
-    posts(post_type: String = "post", limit: Int, skip: Int): [Post]
+    posts(post_type: String = "post", limit: Int, skip: Int, order: OrderInput): [Post]
   }
 `
 


### PR DESCRIPTION
Hello,

The first two commits are to fix bugs, and the last commit is an additional feature.

The additional feature is used in my project and I see it is a very general use case, so I include it in this PR for you to consider. The reason for using `post_date` as the default sorting order is due to the default Wordpress table index:

    KEY `type_status_date` (`post_type`,`post_status`,`post_date`,`ID`),