### PR TITLE
fetch posts from nested categories

### DIFF
--- a/src/modules/Post/connectors/getTermPosts.js
+++ b/src/modules/Post/connectors/getTermPosts.js
@@ -21,7 +21,7 @@ export default function (TermRelationships, Post, TermTaxonomy, settings){
       .then(function (posts) {
         const p = posts.map(post => post.term_taxonomy_id)
         termIds.push(...p)
-        return p;
+        return p
       })
       .then(getTermIds)
     }

--- a/src/modules/Post/connectors/getTermPosts.js
+++ b/src/modules/Post/connectors/getTermPosts.js
@@ -1,28 +1,53 @@
-import {map} from 'lodash'
-
-export default function (TermRelationships, Post, settings){
+export default function (TermRelationships, Post, TermTaxonomy, settings){
   const {wp_prefix} = settings.privateSettings
 
   return function(termId, { post_type, order, limit = 10, skip = 0 }) {
     const orderBy = order ? [Post, order.orderBy, order.direction] : [Post, 'post_date', 'DESC']
-    return TermRelationships.findAll({
-      attributes: [],
-      include: [{
-        model: Post,
+
+    let termIds = [termId]
+
+    function getTermIds(parentTermIds) {
+      if (!parentTermIds.length) return termIds
+
+      return TermTaxonomy.findAll({
+        attributes: ['term_taxonomy_id'],
+        include: [],
         where: {
-          post_type: post_type,
-          post_status: 'publish'
-        }
-      }],
-      where: {
-        term_taxonomy_id: termId
-      },
-      order: [orderBy],
-      limit: limit,
-      offset: skip
-    }).then(posts => {
-      const p = map(posts, post => post[`${wp_prefix}post`])
-      return p
-    })
+          parent: parentTermIds
+        },
+        limit: limit,
+        offset: skip
+      })
+      .then(function (posts) {
+        const p = posts.map(post => post.term_taxonomy_id)
+		termIds.push(...p)
+        return p;
+      })
+      .then(getTermIds)
+    }
+
+    return getTermIds([termId])
+      .then((termIds) => {
+        return TermRelationships.findAll({
+          attributes: [],
+          include: [{
+            model: Post,
+            where: {
+              post_type: post_type,
+              post_status: 'publish'
+            }
+          }],
+          where: {
+            term_taxonomy_id: termIds
+          },
+          order: [orderBy],
+          limit: limit,
+          offset: skip
+        })
+      })
+      .then(posts => {
+        const p = posts.map(post => post[`${wp_prefix}post`])
+        return p
+      })
   }
 }

--- a/src/modules/Post/connectors/getTermPosts.js
+++ b/src/modules/Post/connectors/getTermPosts.js
@@ -20,7 +20,7 @@ export default function (TermRelationships, Post, TermTaxonomy, settings){
       })
       .then(function (posts) {
         const p = posts.map(post => post.term_taxonomy_id)
-		termIds.push(...p)
+        termIds.push(...p)
         return p;
       })
       .then(getTermIds)

--- a/src/modules/Post/connectors/index.js
+++ b/src/modules/Post/connectors/index.js
@@ -4,12 +4,12 @@ import getPostTerms from './getPostTerms'
 import getTermPosts from './getTermPosts'
 import getPostLayout from './getPostLayout'
 
-export default function ({Post, Postmeta, Terms, TermRelationships}, settings) {
+export default function ({Post, Postmeta, Terms, TermRelationships, TermTaxonomy}, settings) {
   return {
     getPost: getPost(Post),
     getPosts: getPosts(Post),
     getPostTerms: getPostTerms(Terms, TermRelationships, settings),
-    getTermPosts: getTermPosts(TermRelationships, Post, settings),
+    getTermPosts: getTermPosts(TermRelationships, Post, TermTaxonomy, settings),
     getPostLayout: getPostLayout(Postmeta),
   }
 }


### PR DESCRIPTION
Hi all!
When fetching posts by categories, the wordpress implementation fetches also from nested categories.
This is not happening in the current implementation of WordExpressSchema.
This PR mirrors wordpress implementation

I hope you enjoy it